### PR TITLE
Added passphrase, _key (private_key, public_key) to filter list

### DIFF
--- a/lib/airbrake/current_user.rb
+++ b/lib/airbrake/current_user.rb
@@ -16,7 +16,7 @@ module Airbrake
 
       # Removes auth-related fields
       attributes = user.attributes.reject do |k, v|
-        /password|token|login|sign_in|per_page|_at$/ =~ k
+        /password|token|login|sign_in|per_page|_at|passphrase|_key$/ =~ k
       end
       # Try to include a URL for the user, if possible.
       if url_method = [:user_url, :admin_user_url].detect {|m| controller.respond_to?(m) }


### PR DESCRIPTION
We store passphrases and keys in our user model, so I believe these should be filtered out as well.

Perhaps it would be best to just use pass instead of both password and passphrase?
