### PR TITLE
Fix deprecated method name in XML conversion

### DIFF
--- a/lib/airbrake_overrides/notice.rb
+++ b/lib/airbrake_overrides/notice.rb
@@ -31,7 +31,7 @@ module Airbrake
             self.backtrace.lines.each do |line|
               backtrace.line(:number => line.number,
                              :file   => line.file,
-                             :method => line.method)
+                             :method => line.method_name)
             end
           end
         end


### PR DESCRIPTION
Needed for newer Airbrake versions (at least 3.1.12).
