### PR TITLE
Fix issue #8: ArgumentError - wrong number of arguments for Line.method

### DIFF
--- a/lib/airbrake_overrides/notice.rb
+++ b/lib/airbrake_overrides/notice.rb
@@ -31,7 +31,7 @@ module Airbrake
             self.backtrace.lines.each do |line|
               backtrace.line(:number => line.number,
                              :file   => line.file,
-                             :method => line.method)
+                             :method => line.method_name)
             end
           end
         end


### PR DESCRIPTION
see: https://github.com/cloudfuji/airbrake_user_attributes/issues/8
